### PR TITLE
Add missing .float() for bf16 inference for FSQ models

### DIFF
--- a/vidtok/modules/regularizers.py
+++ b/vidtok/modules/regularizers.py
@@ -231,7 +231,7 @@ class FSQRegularizer(AbstractRegularizer):
 
             if self.entropy_loss_weight > 0 or self.commitment_loss_weight > 0:
                 # the same as euclidean distance up to a constant
-                distance = -2 * torch.einsum("... i d, j d -> ... i j", original_input, self.implicit_codebook)
+                distance = -2 * torch.einsum("... i d, j d -> ... i j", original_input, self.implicit_codebook.float())
                 prob = (-distance * inv_temperature).softmax(dim=-1)
                 per_sample_probs = rearrange(prob, "b n ... -> (b n) ...")
                 per_sample_entropy = entropy(per_sample_probs).mean()


### PR DESCRIPTION
Simple change that allows BF 16 inference like so:
```
model.to(torch.bfloat16)
with torch.no_grad(), torch.autocast(device_type='cuda:0', dtype=torch.bfloat16):
    _, xrec, _ = model(input)
```