### PR TITLE
enable to use generated frames to pad in inference_reconstruct.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ python scripts/inference_reconstruct.py --config CONFIG --ckpt CKPT --input_vide
 - Specify `VIDEO_PATH` to the path of your test video. We provide an example video in `assets/example.mp4`. 
 - Set `NUM_FRAMES_PER_BATCH` to `17` for causal models and `16` for non-causal models.
 - The reconstructed video is saved in `OUTPUT_DIR`.
+- For causal models, you can choose to add `--pad_gen_frames` to the command line, which may improve the smoothness of the reconstructed video.
 
 ### Performance Evaluation
 We also provide a manuscript `scripts/inference_evaluate.py` to evaluate the video reconstruction performance in PSNR, SSIM and LPIPS.

--- a/vidtok/modules/model_3dcausal.py
+++ b/vidtok/modules/model_3dcausal.py
@@ -728,7 +728,8 @@ class EncoderCausal3DPadding(EncoderCausal3D):
 
     def forward(self, x):
         video_len = x.shape[2]
-        x = pad_at_dim(x, (self.time_padding, 0), dim=2, pad_mode=self.init_pad_mode, value=0.0)
+        if video_len % self.time_downsample_factor != 0:
+            x = pad_at_dim(x, (self.time_padding, 0), dim=2, pad_mode=self.init_pad_mode, value=0.0)
         return super().forward(x)
 
 


### PR DESCRIPTION
Add an option in  inference_reconstruct.py to enable to use generated frames to pad, which may improve the smoothness of the reconstructed video.