### PR TITLE
fix use_checkpoint

### DIFF
--- a/configs/vidtok_fsq_causal_41616_262144.yaml
+++ b/configs/vidtok_fsq_causal_41616_262144.yaml
@@ -20,7 +20,7 @@ model:
         time_downsample_factor: 4
         num_res_blocks: 2
         dropout: 0.0
-        use_checkpoint: true
+        use_checkpoint: false
         init_pad_mode: replicate
         norm_type: layernorm  # layernorm, groupnorm
         fix_encoder: false  # if True, fix it without updating params

--- a/configs/vidtok_fsq_causal_488_262144.yaml
+++ b/configs/vidtok_fsq_causal_488_262144.yaml
@@ -20,7 +20,7 @@ model:
         time_downsample_factor: 4
         num_res_blocks: 2
         dropout: 0.0
-        use_checkpoint: true
+        use_checkpoint: false
         init_pad_mode: replicate
         norm_type: layernorm  # layernorm, groupnorm
         fix_encoder: false  # if True, fix it without updating params

--- a/configs/vidtok_fsq_causal_488_32768.yaml
+++ b/configs/vidtok_fsq_causal_488_32768.yaml
@@ -20,7 +20,7 @@ model:
         time_downsample_factor: 4
         num_res_blocks: 2
         dropout: 0.0
-        use_checkpoint: true
+        use_checkpoint: false
         init_pad_mode: replicate
         norm_type: layernorm  # layernorm, groupnorm
         fix_encoder: false  # if True, fix it without updating params

--- a/configs/vidtok_fsq_causal_488_4096.yaml
+++ b/configs/vidtok_fsq_causal_488_4096.yaml
@@ -20,7 +20,7 @@ model:
         time_downsample_factor: 4
         num_res_blocks: 2
         dropout: 0.0
-        use_checkpoint: true
+        use_checkpoint: false
         init_pad_mode: replicate
         norm_type: layernorm  # layernorm, groupnorm
         fix_encoder: false  # if True, fix it without updating params

--- a/configs/vidtok_fsq_noncausal_41616_262144.yaml
+++ b/configs/vidtok_fsq_noncausal_41616_262144.yaml
@@ -19,7 +19,7 @@ model:
         ch_mult: [1, 2, 4, 4, 4]
         num_res_blocks: 2
         dropout: 0.0
-        use_checkpoint: true
+        use_checkpoint: false
         norm_type: layernorm  # layernorm, groupnorm
         fix_encoder: false
         fix_decoder: false

--- a/configs/vidtok_fsq_noncausal_488_262144.yaml
+++ b/configs/vidtok_fsq_noncausal_488_262144.yaml
@@ -19,7 +19,7 @@ model:
         ch_mult: [1, 2, 4, 4]
         num_res_blocks: 2
         dropout: 0.0
-        use_checkpoint: true
+        use_checkpoint: false
         norm_type: layernorm  # layernorm, groupnorm
         fix_encoder: false
         fix_decoder: false

--- a/configs/vidtok_kl_causal_288_8chn.yaml
+++ b/configs/vidtok_kl_causal_288_8chn.yaml
@@ -22,7 +22,7 @@ model:
         time_downsample_factor: 2
         num_res_blocks: 2
         dropout: 0.0
-        use_checkpoint: true
+        use_checkpoint: false
         init_pad_mode: replicate
         norm_type: layernorm  # layernorm, groupnorm
         fix_encoder: false  # if True, fix it without updating params

--- a/configs/vidtok_kl_causal_41616_4chn.yaml
+++ b/configs/vidtok_kl_causal_41616_4chn.yaml
@@ -20,7 +20,7 @@ model:
         time_downsample_factor: 4
         num_res_blocks: 2
         dropout: 0.0
-        use_checkpoint: true
+        use_checkpoint: false
         init_pad_mode: replicate
         norm_type: layernorm  # layernorm, groupnorm
         fix_encoder: false  # if True, fix it without updating params

--- a/configs/vidtok_kl_causal_444_4chn.yaml
+++ b/configs/vidtok_kl_causal_444_4chn.yaml
@@ -22,7 +22,7 @@ model:
         time_downsample_factor: 4
         num_res_blocks: 2
         dropout: 0.0
-        use_checkpoint: true
+        use_checkpoint: false
         init_pad_mode: replicate
         norm_type: layernorm  # layernorm, groupnorm
         fix_encoder: false  # if True, fix it without updating params

--- a/configs/vidtok_kl_causal_488_16chn.yaml
+++ b/configs/vidtok_kl_causal_488_16chn.yaml
@@ -20,7 +20,7 @@ model:
         time_downsample_factor: 4
         num_res_blocks: 2
         dropout: 0.0
-        use_checkpoint: true
+        use_checkpoint: false
         init_pad_mode: replicate
         norm_type: layernorm  # layernorm, groupnorm
         fix_encoder: false  # if True, fix it without updating params

--- a/configs/vidtok_kl_causal_488_4chn.yaml
+++ b/configs/vidtok_kl_causal_488_4chn.yaml
@@ -20,7 +20,7 @@ model:
         time_downsample_factor: 4
         num_res_blocks: 2
         dropout: 0.0
-        use_checkpoint: true
+        use_checkpoint: false
         init_pad_mode: replicate
         norm_type: layernorm  # layernorm, groupnorm
         fix_encoder: false  # if True, fix it without updating params

--- a/configs/vidtok_kl_causal_488_8chn.yaml
+++ b/configs/vidtok_kl_causal_488_8chn.yaml
@@ -20,7 +20,7 @@ model:
         time_downsample_factor: 4
         num_res_blocks: 2
         dropout: 0.0
-        use_checkpoint: true
+        use_checkpoint: false
         init_pad_mode: replicate
         norm_type: layernorm  # layernorm, groupnorm
         fix_encoder: false  # if True, fix it without updating params

--- a/configs/vidtok_kl_noncausal_41616_4chn.yaml
+++ b/configs/vidtok_kl_noncausal_41616_4chn.yaml
@@ -19,7 +19,7 @@ model:
         ch_mult: [1, 2, 4, 4, 4]
         num_res_blocks: 2
         dropout: 0.0
-        use_checkpoint: true
+        use_checkpoint: false
         norm_type: layernorm  # layernorm, groupnorm
         fix_encoder: false
         fix_decoder: false

--- a/configs/vidtok_kl_noncausal_488_4chn.yaml
+++ b/configs/vidtok_kl_noncausal_488_4chn.yaml
@@ -19,7 +19,7 @@ model:
         ch_mult: [1, 2, 4, 4]
         num_res_blocks: 2
         dropout: 0.0
-        use_checkpoint: true
+        use_checkpoint: false
         norm_type: layernorm  # layernorm, groupnorm
         fix_encoder: false
         fix_decoder: false

--- a/vidtok/modules/model_3dcausal.py
+++ b/vidtok/modules/model_3dcausal.py
@@ -112,14 +112,7 @@ class AttnBlock(nn.Module):
         return rearrange(h_, "b 1 (h w) c -> b c h w", h=h, w=w, c=c, b=b)
 
     def forward(self, x, **kwargs):
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", category=UserWarning)
-            if x.grad is not None or x.grad_fn is not None:
-                use_checkpoint = True
-            else:
-                use_checkpoint = False
-
-        if use_checkpoint:
+        if self.use_checkpoint:
             return checkpoint(self._forward, (x,), self.parameters(), self.use_checkpoint)
         else:
             return self._forward(x)
@@ -333,14 +326,7 @@ class ResnetBlock(nn.Module):
         self.use_checkpoint = use_checkpoint
 
     def forward(self, x, temb):
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", category=UserWarning)
-            if x.grad is not None or x.grad_fn is not None:
-                use_checkpoint = True
-            else:
-                use_checkpoint = False
-
-        if use_checkpoint:
+        if self.use_checkpoint:
             assert temb is None, "checkpointing not supported with temb"
             return checkpoint(self._forward, (x,), self.parameters(), self.use_checkpoint)
         else:
@@ -423,14 +409,7 @@ class ResnetCausalBlock(nn.Module):
         self.use_checkpoint = use_checkpoint
 
     def forward(self, x, temb):
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", category=UserWarning)
-            if x.grad is not None or x.grad_fn is not None:
-                use_checkpoint = True
-            else:
-                use_checkpoint = False
-
-        if use_checkpoint:
+        if self.use_checkpoint:
             assert temb is None, "checkpointing not supported with temb"
             return checkpoint(self._forward, (x,), self.parameters(), self.use_checkpoint)
         else:
@@ -503,14 +482,7 @@ class ResnetCausalBlock1D(nn.Module):
         self.use_checkpoint = use_checkpoint
 
     def forward(self, x, temb):
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", category=UserWarning)
-            if x.grad is not None or x.grad_fn is not None:
-                use_checkpoint = True
-            else:
-                use_checkpoint = False
-
-        if use_checkpoint:
+        if self.use_checkpoint:
             assert temb is None, "checkpointing not supported with temb"
             return checkpoint(self._forward, (x,), self.parameters(), self.use_checkpoint)
         else:

--- a/vidtok/modules/model_3dnoncausal.py
+++ b/vidtok/modules/model_3dnoncausal.py
@@ -158,14 +158,7 @@ class ResnetBlock(nn.Module):
         self.use_checkpoint = use_checkpoint
 
     def forward(self, x, temb):
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", category=UserWarning)
-            if x.grad is not None or x.grad_fn is not None:
-                use_checkpoint = True
-            else:
-                use_checkpoint = False
-
-        if use_checkpoint:
+        if self.use_checkpoint:
             assert temb is None, "checkpointing not supported with temb"
             return checkpoint(self._forward, (x,), self.parameters(), self.use_checkpoint)
         else:
@@ -234,14 +227,7 @@ class ResnetBlock1D(nn.Module):
         self.use_checkpoint = use_checkpoint
 
     def forward(self, x, temb):
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", category=UserWarning)
-            if x.grad is not None or x.grad_fn is not None:
-                use_checkpoint = True
-            else:
-                use_checkpoint = False
-
-        if use_checkpoint:
+        if self.use_checkpoint:
             assert temb is None, "checkpointing not supported with temb"
             return checkpoint(self._forward, (x,), self.parameters(), self.use_checkpoint)
         else:
@@ -304,14 +290,7 @@ class ResnetNoncausalBlock(nn.Module):
         self.use_checkpoint = use_checkpoint
 
     def forward(self, x, temb):
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", category=UserWarning)
-            if x.grad is not None or x.grad_fn is not None:
-                use_checkpoint = True
-            else:
-                use_checkpoint = False
-
-        if use_checkpoint:
+        if self.use_checkpoint:
             assert temb is None, "checkpointing not supported with temb"
             return checkpoint(self._forward, (x,), self.parameters(), self.use_checkpoint)
         else:


### PR DESCRIPTION
1. Simplified the usage of `use_checkpoint` in model_3dcausal.py and model_3dnoncausal.py.
2. Change the default value of `use_checkpoint` in all config files from `true` to `false`.